### PR TITLE
Add "Now" Page and Status Banner

### DIFF
--- a/archetypes/now.md
+++ b/archetypes/now.md
@@ -1,0 +1,24 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+tags: []
+featured: false
+draft: true
+seo_description: ""
+weight: 100
+---
+
+## Overview
+
+[Content goes here]
+
+## Key Learnings
+
+- Point 1
+- Point 2
+- Point 3
+
+## Resources & Links
+
+- [Resource 1](url)
+- [Resource 2](url)

--- a/assets/scss/base/_typography.scss
+++ b/assets/scss/base/_typography.scss
@@ -79,12 +79,13 @@ body {
   font-size: 1rem;
   font-weight: 225; // Default weight for dark mode
   line-height: 1.5;
-  letter-spacing: 0.01em;
+  letter-spacing: 0.022em; // Increased letter spacing for dark mode
   word-spacing: 0.02em;
   font-feature-settings: "kern" 1, "liga" 1;
 
   [data-theme="light"] & {
     font-weight: 350; // Increased weight for light mode
+    letter-spacing: 0.016em; // Decreased letter spacing to compensate
   }
 }
 
@@ -110,9 +111,11 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: 300;
   line-height: 1.2;
   margin-bottom: 1rem;
+  letter-spacing: 0.015em; // Base letter spacing for dark mode
 
   [data-theme="light"] & {
     font-weight: 500;
+    letter-spacing: 0.009em; // Compensate for heavier weight
   }
 }
 

--- a/assets/scss/components/_nav.scss
+++ b/assets/scss/components/_nav.scss
@@ -54,14 +54,14 @@ nav {
 
               &:nth-child(3) .nav-link-wrapper a {
                   color: var(--text);
-                  &:hover { color: var(--text-personality); }
-                  @include animated-underline(var(--text-personality), 3px);
+                  &:hover { color: var(--text-logical); }
+                  @include animated-underline(var(--text-logical), 3px);
               }
 
               &:nth-child(4) .nav-link-wrapper a {
                   color: var(--text);
-                  &:hover { color: var(--text-logical); }
-                  @include animated-underline(var(--text-logical), 3px);
+                  &:hover { color: var(--text-personality); }
+                  @include animated-underline(var(--text-personality), 3px);
               }
           }
       }

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -41,3 +41,4 @@
 @import 'pages/work';
 @import 'pages/work-item';
 @import 'pages/404';
+@import 'pages/now';

--- a/assets/scss/pages/_home.scss
+++ b/assets/scss/pages/_home.scss
@@ -36,3 +36,41 @@
         border: 1px solid var(--surface-default-card-border);
     }
 }
+
+.status-banner {
+    padding: 2rem 0;
+    border-top: 1px solid var(--surface-default-card-border);
+    border-bottom: 1px solid var(--surface-default-card-border);
+    margin: 2rem 0;
+
+    &__content {
+        text-align: center;
+        max-width: 720px;
+        margin: 0 auto;
+
+        p {
+            font-size: 1.125rem;
+            line-height: 1.6;
+            color: var(--text-medium);
+        }
+
+        .status-icon {
+            margin-right: 0.5rem;
+        }
+
+        strong {
+            color: var(--text);
+        }
+
+        .status-link {
+            display: inline-block;
+            margin-left: 0.5rem;
+            color: var(--text-creative);
+            text-decoration: none;
+
+            &:hover {
+                text-decoration: underline;
+            }
+        }
+    }
+}

--- a/assets/scss/pages/_now.scss
+++ b/assets/scss/pages/_now.scss
@@ -1,0 +1,62 @@
+.now-section {
+  padding-top: 5.1428571429rem;
+}
+
+.post-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: $spacing-lg;
+  padding: $spacing-xl 0;
+}
+
+.post-card {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  background: var(--surface-default-card);
+  border: 1px solid var(--surface-default-card-border);
+  border-radius: $border-radius;
+  padding: $spacing-md;
+  transition: transform $transition-duration $transition-easing;
+
+  &:hover {
+      transform: translateY(-4px);
+
+      h3 {
+          color: var(--text-logical);
+          text-decoration-color: var(--text-logical);
+      }
+  }
+
+  &__content {
+      h3 {
+          margin: 0 0 $spacing-sm;
+          transition: color $transition-duration $transition-easing,
+                      text-decoration-color $transition-duration $transition-easing;
+          text-decoration: underline;
+          text-decoration-color: transparent;
+          text-underline-offset: 4px;
+      }
+  }
+
+  .post-meta {
+      display: flex;
+      gap: $spacing-md;
+      align-items: center;
+      color: var(--text-medium);
+      margin-bottom: $spacing-sm;
+      font-size: 0.875rem;
+
+      .tags {
+          display: flex;
+          gap: $spacing-xs;
+          flex-wrap: wrap;
+      }
+
+      .tag {
+          padding: $spacing-xs $spacing-sm;
+          background: color-mix(in srgb, var(--text-medium) 10%, transparent);
+          border-radius: $border-radius-sm;
+      }
+  }
+}

--- a/assets/scss/pages/_now.scss
+++ b/assets/scss/pages/_now.scss
@@ -32,18 +32,20 @@
       }
 
       .tags {
-          display: flex;
-          gap: $spacing-xs;
-          flex-wrap: wrap;
-          margin-top: auto;
-          padding-top: $spacing-sm;
-      }
+        display: flex;
+        gap: $spacing-xs;
+        flex-wrap: wrap;
 
-      .tag {
+        .tag {
+            background: var(--surface-default-card);
+            border: 1px solid var(--surface-default-card-border);
+            padding: $spacing-xs $spacing-sm;
+            border-radius: $border-radius-sm;
+            font-size: 0.875rem;
+        }
+    }
+      time {
           font-size: var(--font-size-sm);
-          padding: $spacing-xs $spacing-sm;
-          background: var(--surface-alt);
-          border-radius: $border-radius-sm;
           color: var(--text-medium);
       }
   }

--- a/assets/scss/pages/_now.scss
+++ b/assets/scss/pages/_now.scss
@@ -3,60 +3,57 @@
 }
 
 .post-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  display: flex;
+  flex-direction: column;
   gap: $spacing-lg;
   padding: $spacing-xl 0;
+  max-width: 800px;
+  margin: 0 auto;
 }
 
 .post-card {
   display: block;
   text-decoration: none;
   color: inherit;
-  background: var(--surface-default-card);
-  border: 1px solid var(--surface-default-card-border);
+  transition: all $transition-duration $transition-easing;
   border-radius: $border-radius;
   padding: $spacing-md;
-  transition: transform $transition-duration $transition-easing;
-
-  &:hover {
-      transform: translateY(-4px);
-
-      h3 {
-          color: var(--text-logical);
-          text-decoration-color: var(--text-logical);
-      }
-  }
 
   &__content {
       h3 {
+          font-size: 1.5rem;
           margin: 0 0 $spacing-sm;
+          color: var(--text-medium);
           transition: color $transition-duration $transition-easing,
                       text-decoration-color $transition-duration $transition-easing;
           text-decoration: underline;
           text-decoration-color: transparent;
           text-underline-offset: 4px;
       }
-  }
-
-  .post-meta {
-      display: flex;
-      gap: $spacing-md;
-      align-items: center;
-      color: var(--text-medium);
-      margin-bottom: $spacing-sm;
-      font-size: 0.875rem;
 
       .tags {
           display: flex;
           gap: $spacing-xs;
           flex-wrap: wrap;
+          margin-top: auto;
+          padding-top: $spacing-sm;
       }
 
       .tag {
+          font-size: var(--font-size-sm);
           padding: $spacing-xs $spacing-sm;
-          background: color-mix(in srgb, var(--text-medium) 10%, transparent);
+          background: var(--surface-alt);
           border-radius: $border-radius-sm;
+          color: var(--text-medium);
+      }
+  }
+
+  &:hover {
+      background: color-mix(in srgb, var(--text-logical) 4%, transparent);
+
+      h3 {
+          color: var(--text-logical);
+          text-decoration-color: var(--text-logical);
       }
   }
 }

--- a/assets/scss/pages/_work-item.scss
+++ b/assets/scss/pages/_work-item.scss
@@ -13,15 +13,13 @@
         .work-item__meta {
             display: flex;
             gap: $spacing-md;
-            align-items: center;
-            color: var(--text-medium);
-
-            .company {
-                font-weight: 500;
-            }
+            align-items: baseline;
+            flex-wrap: wrap;
 
             .date {
-                font-size: 0.875rem;
+                display: inline-block;
+                line-height: 1.2;
+                color: var(--text-medium);
             }
 
             .tags {
@@ -30,10 +28,13 @@
                 flex-wrap: wrap;
 
                 .tag {
-                    font-size: 0.875rem;
+                    background: var(--surface-default-card);
+                    border: 1px solid var(--surface-default-card-border);
                     padding: $spacing-xs $spacing-sm;
-                    background: color-mix(in srgb, var(--text-medium) 10%, transparent);
                     border-radius: $border-radius-sm;
+                    font-size: 0.875rem;
+                    line-height: 1.2;
+                    display: inline-block;
                 }
             }
         }

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -13,7 +13,7 @@ I'm a Product Designer who turns complex challenges into elegant solutions. Curr
 
 I believe in the power of thoughtful design to transform ideas into successful products. My approach combines strategic thinking with pixel-perfect execution, especially when working with startups and scaling teams.
 
-> Want the formal version? Check out my [CV](/assets/files/Kyle_Kochanek_CV.pdf)
+📄 [Download my CV](/assets/files/Kyle_Kochanek_CV.pdf)
 
 ### Where I make an impact
 

--- a/content/now/_index.md
+++ b/content/now/_index.md
@@ -4,8 +4,10 @@ type: "now"
 description: "Digital garden of thoughts, learnings, and current adventures"
 ---
 
-# Digital Garden
+# 🌱 Whats Growing
 
-Welcome to my digital garden - a space where I share my thoughts, learnings, and current adventures. This is less of a traditional blog and more of a growing collection of ideas and explorations.
+Welcome to my living, breathing corner of the internet! This is my "Now" page meets digital garden - a constantly evolving space where I'm actively tending to ideas, projects, and learnings in real-time.
 
-Use the search below to explore topics or browse through the latest entries.
+Think of this less as a polished blog and more like peeking over my shoulder as I explore, experiment, and grow. Here you'll find my current obsessions, half-baked thoughts, and works-in-progress. Some ideas are seedlings, others are in full bloom, and a few might be lovely weeds I've decided to keep.
+
+Feel free to wander through my garden - use the search below to explore specific topics, or simply meander through the latest updates. Unlike a traditional blog, entries here may evolve and grow as I learn more.

--- a/content/now/_index.md
+++ b/content/now/_index.md
@@ -1,0 +1,11 @@
+---
+title: "Now"
+type: "now"
+description: "Digital garden of thoughts, learnings, and current adventures"
+---
+
+# Digital Garden
+
+Welcome to my digital garden - a space where I share my thoughts, learnings, and current adventures. This is less of a traditional blog and more of a growing collection of ideas and explorations.
+
+Use the search below to explore topics or browse through the latest entries.

--- a/content/now/building-digital-garden.md
+++ b/content/now/building-digital-garden.md
@@ -1,0 +1,19 @@
+---
+title: "Building My Digital Garden"
+date: 2024-03-21
+tags: ["Design", "Development", "Hugo", "Digital Garden"]
+featured: true
+draft: false
+seo_description: "A look into the process of building and maintaining my digital garden using Hugo"
+---
+
+## Overview
+
+I've always been fascinated by the concept of digital gardens - spaces that grow and evolve with our thoughts and learnings. This post documents my journey in creating one.
+
+## What's a Digital Garden?
+
+Unlike traditional blogs that are organized chronologically, a digital garden is:
+- � A collection of ideas that grow over time
+- 🔄 Content that's regularly updated and refined
+- 🌿 Interconnected thoughts and concepts

--- a/hugo.toml
+++ b/hugo.toml
@@ -19,10 +19,6 @@ title = "Kyle Kochanek"
     name = "About"
     url = "/about/"
     weight = 3
-  [[menu.main]]
-    name = "Resume ↓"
-    url = "/assets/files/Kyle_Kochanek_Resume.pdf"
-    weight = 4
 
 [build]
   writeStats = true

--- a/hugo.toml
+++ b/hugo.toml
@@ -12,13 +12,17 @@ title = "Kyle Kochanek"
     url = "/work/"
     weight = 1
   [[menu.main]]
+    name = "Now"
+    url = "/now/"
+    weight = 2
+  [[menu.main]]
     name = "About"
     url = "/about/"
-    weight = 2
+    weight = 3
   [[menu.main]]
     name = "Resume ↓"
     url = "/assets/files/Kyle_Kochanek_Resume.pdf"
-    weight = 3
+    weight = 4
 
 [build]
   writeStats = true

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -111,6 +111,18 @@
     </div>
 </header>
 
+<section class="status-banner">
+    <div class="content-wrapper">
+        <div class="status-banner__content">
+            <p>
+                <span class="status-icon">💼</span>
+                <strong>Current Status:</strong> Not actively seeking new opportunities, but always excited to connect and discuss design, systems thinking, or share industry insights.
+                <a href="mailto:hello+website@kylekochanek.com" class="status-link">Let's chat! →</a>
+            </p>
+        </div>
+    </div>
+</section>
+
 {{ $featured := where .Site.RegularPages "Params.featured" true }}
 {{ with $featured }}
 <section class="featured-work">

--- a/layouts/now/list.html
+++ b/layouts/now/list.html
@@ -1,0 +1,37 @@
+{{ define "main" }}
+<section class="now-section page-content">
+    {{ .Content }}
+
+    <div class="search-container" role="search" aria-label="Search through posts">
+        <label for="postSearch" class="search-label">
+            <span class="search-label__text">Search posts by title, tags, or content</span>
+            <div class="search-input-wrapper">
+                <input
+                    type="search"
+                    id="postSearch"
+                    class="search-input"
+                    placeholder="Try searching for topics or keywords"
+                    autocomplete="off"
+                    aria-expanded="false"
+                    aria-controls="searchResults"
+                    aria-describedby="searchHint"
+                >
+                <button
+                    type="button"
+                    class="search-clear"
+                    aria-label="Clear search"
+                    hidden
+                >
+                    <span aria-hidden="true">×</span>
+                </button>
+            </div>
+        </label>
+    </div>
+
+    <div class="post-grid">
+        {{ range .Pages.ByDate.Reverse }}
+            {{ partial "post-card.html" . }}
+        {{ end }}
+    </div>
+</section>
+{{ end }}

--- a/layouts/now/list.html
+++ b/layouts/now/list.html
@@ -34,4 +34,38 @@
         {{ end }}
     </div>
 </section>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+    const searchInput = document.getElementById('postSearch');
+    const clearButton = document.querySelector('.search-clear');
+    const posts = document.querySelectorAll('.post-card');
+
+    const searchPosts = () => {
+        const query = searchInput.value.toLowerCase();
+
+        posts.forEach(post => {
+            const title = post.querySelector('h3').textContent.toLowerCase();
+            const tags = Array.from(post.querySelectorAll('.tag')).map(tag => tag.textContent.toLowerCase());
+            const description = post.querySelector('p')?.textContent.toLowerCase() || '';
+
+            const isMatch = title.includes(query) ||
+                           tags.some(tag => tag.includes(query)) ||
+                           description.includes(query);
+
+            post.style.display = isMatch ? 'block' : 'none';
+        });
+
+        clearButton.hidden = !searchInput.value;
+    };
+
+    searchInput.addEventListener('input', searchPosts);
+
+    clearButton.addEventListener('click', () => {
+        searchInput.value = '';
+        searchPosts();
+        searchInput.focus();
+    });
+});
+</script>
 {{ end }}

--- a/layouts/now/single.html
+++ b/layouts/now/single.html
@@ -1,0 +1,25 @@
+{{ define "main" }}
+<article class="work-item">
+    <div class="content-wrapper">
+        <div class="work-item__header">
+            <h1>{{ .Title }}</h1>
+            <div class="work-item__meta">
+                <time class="date" datetime="{{ .Date.Format "2006-01-02" }}">
+                    {{ .Date.Format "January 2, 2006" }}
+                </time>
+                {{ with .Params.tags }}
+                <div class="tags">
+                    {{ range . }}
+                    <span class="tag">{{ . }}</span>
+                    {{ end }}
+                </div>
+                {{ end }}
+            </div>
+        </div>
+
+        <div class="work-item__content">
+            {{ .Content }}
+        </div>
+    </div>
+</article>
+{{ end }}

--- a/layouts/partials/post-card.html
+++ b/layouts/partials/post-card.html
@@ -1,20 +1,40 @@
 <a class="post-card" href="{{ .RelPermalink }}">
-  <div class="post-card__content">
-      <h3>{{ .Title }}</h3>
-      <div class="post-meta">
-          <time datetime="{{ .Date.Format "2006-01-02" }}">
-              {{ .Date.Format "January 2, 2006" }}
-          </time>
-          {{ with .Params.tags }}
-          <div class="tags">
-              {{ range . }}
-              <span class="tag">{{ . }}</span>
-              {{ end }}
-          </div>
-          {{ end }}
-      </div>
-      {{ with .Description }}
-      <p class="post-card__description">{{ . }}</p>
-      {{ end }}
-  </div>
+    {{ if .Params.thumbnail }}
+        <div class="post-card__media">
+            {{ if .Resources }}
+                {{ $thumbnail := .Resources.GetMatch .Params.thumbnail }}
+                {{ with $thumbnail }}
+                    {{ $tiny := .Resize "20x webp q80" }}
+                    {{ $small := .Resize "400x webp q80" }}
+                    {{ $medium := .Resize "600x webp q80" }}
+                    <img
+                        src="{{ $small.RelPermalink }}"
+                        srcset="{{ $small.RelPermalink }} 400w, {{ $medium.RelPermalink }} 600w"
+                        sizes="(max-width: 400px) 400px, 600px"
+                        alt="{{ $.Title }}"
+                        loading="lazy"
+                        decoding="async"
+                    >
+                {{ end }}
+            {{ end }}
+        </div>
+    {{ end }}
+    <div class="post-card__content">
+        <h3>{{ .Title }}</h3>
+        <div class="post-meta">
+            <time datetime="{{ .Date.Format "2006-01-02" }}">
+                {{ .Date.Format "January 2, 2006" }}
+            </time>
+        </div>
+        {{ with .Description }}
+            <p>{{ . }}</p>
+        {{ end }}
+        {{ with .Params.tags }}
+            <div class="tags">
+                {{ range . }}
+                    <span class="tag">{{ . }}</span>
+                {{ end }}
+            </div>
+        {{ end }}
+    </div>
 </a>

--- a/layouts/partials/post-card.html
+++ b/layouts/partials/post-card.html
@@ -1,0 +1,20 @@
+<a class="post-card" href="{{ .RelPermalink }}">
+  <div class="post-card__content">
+      <h3>{{ .Title }}</h3>
+      <div class="post-meta">
+          <time datetime="{{ .Date.Format "2006-01-02" }}">
+              {{ .Date.Format "January 2, 2006" }}
+          </time>
+          {{ with .Params.tags }}
+          <div class="tags">
+              {{ range . }}
+              <span class="tag">{{ . }}</span>
+              {{ end }}
+          </div>
+          {{ end }}
+      </div>
+      {{ with .Description }}
+      <p class="post-card__description">{{ . }}</p>
+      {{ end }}
+  </div>
+</a>


### PR DESCRIPTION
## Overview
This PR introduces a new "Now" page feature - a digital garden concept for sharing current thoughts, projects, and status updates. It also adds a status banner to communicate availability for new opportunities.

## Key Changes
- Added new "Now" section with digital garden functionality
  - Created new `now` archetype template
  - Implemented searchable posts listing
  - Added single post template with tags support
- Updated navigation structure to include Now page
- Added status banner on homepage indicating availability
- Typography improvements:
  - Adjusted letter spacing and font weights for better readability
  - Enhanced dark/light mode text rendering
- Refined tag styling and layout across components

## Technical Details
- New templates:
  - `/layouts/now/list.html`
  - `/layouts/now/single.html`
  - `/layouts/partials/post-card.html`
- Added SCSS modules:
  - `_now.scss` for Now page styling
  - Updated `_typography.scss` for font adjustments
- Modified navigation menu order in `hugo.toml`

