### PR TITLE
work update

### DIFF
--- a/content/now/building-digital-garden.md
+++ b/content/now/building-digital-garden.md
@@ -2,7 +2,7 @@
 title: "Building My Digital Garden"
 date: 2024-03-21
 tags: ["Design", "Development", "Hugo", "Digital Garden"]
-featured: true
+featured: false
 draft: false
 seo_description: "A look into the process of building and maintaining my digital garden using Hugo"
 ---

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -35,11 +35,11 @@
             <div class="hero__media-info">
               <div class="hero__media-info-block">
                   <h3 class="company-status">Previously</h3>
-                  <p class="company-name">Roadtrippers, Roadpass</p>
+                  <p class="company-name">Roadtrippers, PokerAtlas</p>
               </div>
               <div class="hero__media-info-block">
                   <h3 class="company-status">@ Now</h3>
-                  <p class="company-name">PokerAtlas</p>
+                  <p class="company-name">Transitioning to a new role</p>
               </div>
           </div>
         </div>


### PR DESCRIPTION
## Employment Status and Content Updates

### Changes Made
- Updated employment status in homepage to reflect current transition period
- Changed previously listed company from "Roadtrippers, Roadpass" to "Roadtrippers, PokerAtlas"
- Updated current status from "PokerAtlas" to "Transitioning to a new role"
- Set featured status to false for "Building My Digital Garden" article

### Purpose
This PR updates the site content to accurately reflect current employment status and adjusts content visibility settings.

### Testing
- Verify homepage displays updated employment information correctly
- Confirm "Building My Digital Garden" article is no longer featured but still accessible
