### PR TITLE
Kyle/about layout update

### DIFF
--- a/assets/scss/components/_avatar.scss
+++ b/assets/scss/components/_avatar.scss
@@ -19,9 +19,9 @@
         backface-visibility: hidden;
         contain: layout style paint;
 
-            @media (max-width: $breakpoint-md) {
-              max-width: 24vw;
-            }
+        @media (max-width: $breakpoint-md) {
+            max-width: 24vw;
+        }
     }
 
     @keyframes rotateOnLoad {

--- a/assets/scss/components/_avatar.scss
+++ b/assets/scss/components/_avatar.scss
@@ -1,6 +1,7 @@
 .avatar-figure {
     margin: 0;
     width: 100%;
+    padding-bottom: 1.5rem;
 
     .avatar-image {
         width: 100%;
@@ -17,6 +18,10 @@
         transform: translate3d(0, 0, 0); // Force hardware acceleration
         backface-visibility: hidden;
         contain: layout style paint;
+
+            @media (max-width: $breakpoint-md) {
+              max-width: 24vw;
+            }
     }
 
     @keyframes rotateOnLoad {

--- a/assets/scss/layout/_content.scss
+++ b/assets/scss/layout/_content.scss
@@ -40,7 +40,7 @@ nav {
 
 .about-grid {
     display: grid;
-    grid-template-columns: 1fr 3fr;
+    grid-template-columns: 1fr;
     gap: $spacing-xl;
     max-width: 800px;
     margin: 0 auto;

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -7,7 +7,7 @@ type: "about"
 
 ## Welcome to my corner of the internet 👋
 
-I'm a Product Designer who turns complex challenges into elegant solutions. Currently, I'm crafting B2B and B2C experiences at PokerAtlas, with systematic thinking and creative problem-solving.
+I'm a Product Designer who turns complex challenges into elegant solutions. Currently, I'm crafting B2B and B2C experiences at <a href="https://www.breakline.org" target="_blank" rel="noopener noreferrer">BreakLine</a>, with systematic thinking and creative problem-solving.
 
 ### What drives me
 


### PR DESCRIPTION
This pull request includes updates to the SCSS styles for layout and components, as well as a content update in the `about` section. The most important changes include adjustments to the avatar and grid layout styles and an update to the designer's current role and company in the `about` page.

### Style updates:

* [`assets/scss/components/_avatar.scss`](diffhunk://#diff-3b74f85626230c9249dc7557f3a4f0df714adf3d1b8942e603846b165880838aR4): Added padding to `.avatar-figure` and introduced a media query to set a `max-width` for `.avatar-image` on smaller screens (`max-width: $breakpoint-md`). These changes aim to improve the avatar's responsiveness and spacing. [[1]](diffhunk://#diff-3b74f85626230c9249dc7557f3a4f0df714adf3d1b8942e603846b165880838aR4) [[2]](diffhunk://#diff-3b74f85626230c9249dc7557f3a4f0df714adf3d1b8942e603846b165880838aR21-R24)
* [`assets/scss/layout/_content.scss`](diffhunk://#diff-72abfc7ab13f0353a307d30c73a1cc5e490c6f82a7a868a9533b79ba89b3f1c6L43-R43): Updated the `.about-grid` layout to use a single column (`grid-template-columns: 1fr`) instead of two columns, simplifying the layout for better readability.

### Content update:

* [`content/about/index.md`](diffhunk://#diff-7b878116573933b45ecc0b2918bd8df9ffaa43e9299910901ee2c22125a6aaf1L10-R10): Updated the designer's current role and company from PokerAtlas to BreakLine, including a link to the new company with proper accessibility attributes.